### PR TITLE
changed solids according to specs

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -137,8 +137,7 @@ model Solids {
   childId   Int
   reaction  String?
   note      String?
-  date      DateTime
-  time      DateTime
+  dateTime  DateTime @default(now())
   isDeleted Boolean  @default(false)
 
   // Relations
@@ -150,7 +149,8 @@ model SolidCat {
   id           Int     @id @default(autoincrement())
   solidId      Int
   itemId       Int
-  weightVolume Float?
+  numberOfUnits Float?
+  unitOfMeasure String @default("g")
   isDeleted    Boolean @default(false)
 
   // Relations
@@ -171,7 +171,6 @@ model CategoryItems {
   categoryId Int
   isDefault  Boolean
   parentId   Int?
-  isSolid    Boolean
   itemName   String
   isDeleted  Boolean @default(false)
 

--- a/src/feeding/solid/dto/create-solid-dto.ts
+++ b/src/feeding/solid/dto/create-solid-dto.ts
@@ -1,15 +1,19 @@
 import { Type } from "class-transformer";
-import { IsArray, IsDateString, IsInt, IsNotEmpty, IsOptional, IsString, Min, ValidateNested } from "class-validator";
+import { IsArray, IsDateString, IsInt, IsNotEmpty, IsNotEmptyObject, IsOptional, IsString, Min, ValidateNested } from "class-validator";
 
-class CategoryCreateDto {
+ export class CategoryCreateDto {
     @IsNotEmpty()
     @IsInt()
     @Min(0)
-    weightVolume: number;
+    numberOfUnits: number;
+
+    @IsNotEmpty()
+    @IsString()
+    unitOfMeasure: string
 
     @IsNotEmpty()
     @IsInt()
-    itemId: number;
+    id: number;
 }
 
 export class CreateSolidDto {
@@ -27,15 +31,10 @@ export class CreateSolidDto {
 
     @IsNotEmpty()
     @IsDateString()
-    date: string;
-
-    @IsNotEmpty()
-    @IsDateString()
-    time: string;
+    dateTime: string;
 
     @IsArray()
-    @IsOptional()
     @ValidateNested({ each: true })
     @Type(() => CategoryCreateDto)
-    categories: CategoryCreateDto[];
+    ingredients: CategoryCreateDto[];
 }

--- a/src/feeding/solid/dto/update-solid-dto.ts
+++ b/src/feeding/solid/dto/update-solid-dto.ts
@@ -1,4 +1,6 @@
-import { IsDateString, IsOptional, IsString } from "class-validator";
+import { Type } from "class-transformer";
+import { IsArray, IsDateString, IsOptional, IsString, ValidateNested } from "class-validator";
+import { CategoryCreateDto } from "./create-solid-dto";
 
 export class UpdateSolidDto {
     @IsOptional()
@@ -11,9 +13,11 @@ export class UpdateSolidDto {
   
     @IsOptional()
     @IsDateString()
-    date?: string;
+    dateTime?: string;
   
+    @IsArray()
     @IsOptional()
-    @IsDateString()
-    time?: string;
+    @ValidateNested({ each: true })
+    @Type(() => CategoryCreateDto)
+    ingredients: CategoryCreateDto[];
   }

--- a/src/feeding/solid/solid.service.ts
+++ b/src/feeding/solid/solid.service.ts
@@ -27,9 +27,9 @@ export class SolidService {
   async create(createSolidDto: CreateSolidDto, parentId: number) {
     await this.verifyParentChildRelation(parentId, createSolidDto.childId);
 
-    if (createSolidDto.categories) {
-      for (const category of createSolidDto.categories) {
-        const itemId = category.itemId;
+    if (createSolidDto.ingredients) {
+      for (const category of createSolidDto.ingredients) {
+        const itemId = category.id;
         const categoryItemExists = await this.databaseService.categoryItems.findFirst({
           where: {
             itemId,
@@ -53,17 +53,17 @@ export class SolidService {
     const solidData: Prisma.SolidsCreateInput = {
       reaction: createSolidDto.reaction,
       note: createSolidDto.note,
-      date: createSolidDto.date,
-      time: createSolidDto.time,
+      dateTime: createSolidDto.dateTime,
       child: {
         connect: { childId: createSolidDto.childId },
       },
-      categories: createSolidDto.categories
+      categories: createSolidDto.ingredients
         ? {
-          create: createSolidDto.categories.map(category => ({
-            weightVolume: category.weightVolume,
+          create: createSolidDto.ingredients.map(category => ({
+            numberOfUnits: category.numberOfUnits,
+            unitOfMeasure: category.unitOfMeasure,
             categoryItem: {
-              connect: { itemId: category.itemId },
+              connect: { itemId: category.id },
             },
           })),
         }
@@ -76,29 +76,43 @@ export class SolidService {
 
   async findAll(parentId: number, childId: number, limit: number, offset: number) {
     await this.verifyParentChildRelation(parentId, childId);
-    return this.databaseService.solids.findMany({
+
+    const data = await this.databaseService.solids.findMany({
       where: {
         childId: childId,
         isDeleted: false,
-
-      },
-      include: {
         categories: {
-          include: {
+          some: {
+            isDeleted: false
+          }
+        }
+      },
+      select: {
+        solidId: true,
+        reaction: true,
+        note: true,
+        dateTime: true,
+        categories: {
+          select: {
+            id: true,
+            numberOfUnits: true,
+            unitOfMeasure: true,
             categoryItem: {
-              include: {
-                category: true,
+              select: {
+                itemId: true,
+                itemName: true,
               }
-            },
-          },
-        },
+            }
+          }
+        }
       },
       take: limit,
       skip: offset,
       orderBy: {
-        date: 'desc'
+        dateTime: 'desc'
       }
     });
+    return transformResponse(data);
   }
 
   async findOne(parentId: number, solidId: number) {
@@ -143,10 +157,10 @@ export class SolidService {
 
     await this.verifyParentChildRelation(parentId, childId);
 
-    return this.databaseService.solids.findMany({
+    return transformResponse(this.databaseService.solids.findMany({
       where: {
         childId: childId,
-        date: {
+        dateTime: {
           gte: startDate,
           lte: endDate,
         },
@@ -163,37 +177,76 @@ export class SolidService {
           },
         },
       },
-    });
+    }));
   }
 
   async update(id: number, parentId: number, updateSolidDto: UpdateSolidDto) {
+    const { ingredients, ...solidData } = updateSolidDto;
+
     const solid = await this.databaseService.solids.findUnique({
       where: {
         solidId: id,
-        isDeleted: false
+        isDeleted: false,
+      },
+      include: {
+        categories: { select: { id: true, isDeleted: true } },
       },
     });
 
     if (!solid) {
       throw new NotFoundException(`Solid with id ${id} not found.`);
     }
-    const parentChildRelation = await this.databaseService.parentChild.findFirst({
-      where: {
-        parentId: parentId,
-        childId: solid.childId,
-        status: 'Active',
-      },
-    });
 
-    if (!parentChildRelation) {
-      throw new UnauthorizedException(`This solid does not belong to the authenticated parent's child.`);
+    await this.verifyParentChildRelation(parentId, solid.childId);
+
+    if (ingredients && ingredients.length > 0) {
+      const existingIngredientIds = solid.categories.map(ingredient => ingredient.id);
+      const ingredientIdsToUpdate = ingredients.map(i => i.id);
+
+      const ingredientsToDelete = existingIngredientIds.filter(id => !ingredientIdsToUpdate.includes(id));
+      const ingredientsToAdd = ingredients.filter(i => !existingIngredientIds.includes(i.id));
+
+      await this.databaseService.solidCat.updateMany({
+        where: {
+          id: { in: ingredientsToDelete },
+          solidId: id,
+        },
+        data: { isDeleted: true },
+      });
+
+      await Promise.all(
+        ingredientsToAdd.map(ingredient =>
+          this.databaseService.solidCat.create({
+            data: {
+              unitOfMeasure: ingredient.unitOfMeasure,
+              numberOfUnits: ingredient.numberOfUnits,
+              solid: {
+                connect: {
+                  solidId: id,
+                },
+              },
+              categoryItem: {
+                connect: {
+                  itemId: ingredient.id,
+                },
+              },
+            },
+          })
+        )
+      );
+    } else if (ingredients && ingredients.length === 0) {
+      await this.databaseService.solidCat.updateMany({
+        where: { solidId: id },
+        data: { isDeleted: true },
+      });
     }
 
     return this.databaseService.solids.update({
       where: { solidId: id },
-      data: updateSolidDto,
+      data: solidData,
     });
   }
+
 
   async remove(id: number, parentId: number) {
 
@@ -208,27 +261,33 @@ export class SolidService {
       throw new NotFoundException(`Solid with id ${id} not found.`);
     }
 
-    const parentChildRelation = await this.databaseService.parentChild.findFirst({
-      where: {
-        parentId: parentId,
-        childId: solid.childId,
-        status: 'Active',
-      },
-    });
-
-    if (!parentChildRelation) {
-      throw new UnauthorizedException(`This solid does not belong to the authenticated parent's child.`);
-    }
+    await this.verifyParentChildRelation(parentId, solid.childId);
 
     await this.databaseService.solidCat.updateMany({
       where: { solidId: id },
-      data: { isDeleted: false }
+      data: { isDeleted: true }
     });
 
     return this.databaseService.solids.update({
       where: { solidId: id },
-      data: { isDeleted: false }
+      data: { isDeleted: true }
     });
   }
 
+}
+
+
+function transformResponse(data) {
+  return data.map(item => ({
+    id: item.solidId,
+    reaction: item.reaction,
+    note: item.note,
+    dateTime: item.dateTime,
+    ingredients: item.categories.map(category => ({
+      id: category.id,
+      name: category.categoryItem.itemName,
+      unitOfMeasure: category.unitOfMeasure,
+      numberOfUnits: category.numberOfUnits || 0
+    }))
+  }));
 }


### PR DESCRIPTION
This update modifies the JSON response structure for retrieving solid feeding entries to align with the specified SolidFeedingResponse schema.
 example json body :
[
  {
    "id": 5,
    "reaction": "Loved it",
    "note": "Some sample note",
    "dateTime": "2024-11-06T15:30:00+00",
    "ingredients": [
      {
        "id": 3,
        "name": "Pineapple",
        "unitOfMeasure": "g",
        "numberOfUnits": 12
      }
    ]
  },
  ...
]